### PR TITLE
Replace `::set-output` with `$GITHUB_OUTPUT`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,4 +50,4 @@ runs:
                 })
             '
         )
-        echo "::set-output name=current-projects::${CURRENT_PROJECTS}"
+        echo "current-projects=${CURRENT_PROJECTS}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/